### PR TITLE
Using directive's element instead of adding arbitray id and selecting it

### DIFF
--- a/src/ngclipboard.js
+++ b/src/ngclipboard.js
@@ -8,14 +8,7 @@
                 ngclipboardError: '&'
             },
             link: function(scope, element) {
-
-                var _id = element.attr('id');
-                if (!_id) {
-                    element.attr('id', 'ngclipboard' + Date.now());
-                    _id = element.attr('id');
-                }
-
-                var clipboard = new Clipboard('#' + _id);
+                var clipboard = new Clipboard(element[0]);
 
                 clipboard.on('success', function(e) {
                     scope.ngclipboardSuccess({


### PR DESCRIPTION
Since clipboard.js can handle an element, there's no need to create an unnecessary id and then sending the selector.
We can instead send the element itself to the `Clipboard` constructor.
This might solve #4 since we won't be adding IDs anymore.
